### PR TITLE
Fix: Streamline Next.js build and export process for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
       # ② 依存インストール & Next.js ビルド＋書き出し
       - run: npm ci
-      - run: npm run build && npm run export      # docs/ に静的ファイル生成
+      - run: npm run deploy      # docs/ に静的ファイル生成
 
       # Jekyll を無効化（.nojekyll が無いと CSS が壊れる）
       - run: touch docs/.nojekyll

--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
   "scripts": {
     "dev": "next dev --turbopack -p 9002",
     "build": "next build",
-    "postexport": "mv out docs", 
-    "deploy": "npm run build",
+    "deploy": "npm run build && mv out docs",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "start": "next start",
-    "export": "next export",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
This commit addresses a build error related to the Next.js static export for GitHub Pages.

The `next.config.ts` file specifies `output: 'export'`, which means `next build` already handles the static site generation into the `out/` directory.

The previous build process in the GitHub Actions workflow and `package.json` had redundant and conflicting steps:
- It called `next export` separately after `next build`.
- The `mv out docs` command was tied to the `postexport` script, which might not run if `next export` failed.

This commit implements the following changes:

1.  **`package.json`:**
    - Removed the `export` script (`"export": "next export"`).
    - Modified the `deploy` script to `"deploy": "npm run build && mv out docs"`. This ensures `mv out docs` runs directly after `next build`.
    - Removed the `postexport` script (`"postexport": "mv out docs"`) as its functionality is now part of the `deploy` script.

2.  **`.github/workflows/deploy.yml`:**
    - Changed the build step from `run: npm ci && npm run build && npm run export` to `run: npm ci && npm run deploy`. This utilizes the updated and simplified `deploy` script.

These changes ensure a more robust and streamlined build process, where `next build` creates the static export in `out/`, which is then correctly moved to `docs/` for deployment to GitHub Pages.